### PR TITLE
Feat: Include Error log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 sophos_firewall_audit/results_html*
 firewalls.yaml
 /rule_export*
+error.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophos-firewall-audit"
-version = "1.0.8"
+version = "1.0.9"
 description = "Sophos Firewall Audit"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophos_firewall_audit/postaudit_web.py
+++ b/sophos_firewall_audit/postaudit_web.py
@@ -105,11 +105,20 @@ if __name__ == "__main__":
     with open(os.path.join(parent_directory, "results.json"), "r", encoding="utf-8") as fn:
         results = json.loads(fn.read())
 
+    error_list = []
+    try:
+        with open(os.path.join(parent_directory, "error.log"), "r", encoding="utf-8") as fn:
+            for line in fn.readlines:
+                error_list.append(line.strip())
+    except FileNotFoundError:
+        logging.warning("File error.log not found. This is normal if there were no connectivity errors during the audit.")
+
     html_table = parse_results(results)
 
     msg_subject = "Firewall Audit Report"
     template = env.get_template("email_body_web.j2")
     msg_body = template.render(html_table=html_table,
+                               error_list=error_list,
                                url=os.environ["URL"])
     logging.info("Sending email...")    
     send_email(msg_subject, msg_body, os.environ["SMTP_RECIPIENT"])

--- a/sophos_firewall_audit/sophosfirewallaudit.py
+++ b/sophos_firewall_audit/sophosfirewallaudit.py
@@ -172,6 +172,8 @@ def main():
         os.mkdir(local_dirname)
         os.mkdir(web_dirname)
 
+    error_list = []
+
     for firewall in firewalls:
         fw = SophosFirewall(
             username=os.environ['VAULT_SECRET_KEY'] if args.use_vault else fw_username,
@@ -184,6 +186,7 @@ def main():
             fw.login()
         except Exception as Error:
             logging.error(f"Error connecting to firewall {firewall['hostname']}: {Error}")
+            error_list.append(f"{firewall['hostname']: {Error}}")
             continue
         
         if not args.rule_export:
@@ -196,7 +199,11 @@ def main():
         generate_audit_output(status_dict, local_dirname, web_dirname)
     elif args.rule_export:
         generate_rule_output(firewalls, local_dirname, web_dirname)
-    
+
+    if error_list:
+        with open("error.log", "w", encoding="utf-8") as f:
+            for line in error_list:
+                f.write(f"{line}\n")
 
 if __name__ == "__main__":
     main()

--- a/sophos_firewall_audit/templates/email_body_web.j2
+++ b/sophos_firewall_audit/templates/email_body_web.j2
@@ -5,3 +5,11 @@
 Please review the detailed results <a href="{{ url }}">here</a>.
 <br/>
 <br/>
+{% if error_list %}
+Errors:
+<br/>
+{% for line in error_list %}
+{{ line }}
+<br/>
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Writes an `error.log` file which captures any errors connecting to the firewalls during the audit.  The log file is also brought into the postaudit task to include the error log in the body of the email notification.  