### PR TITLE
fix: Snmpv3 user lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophos-firewall-audit"
-version = "1.0.9"
+version = "1.0.10"
 description = "Sophos Firewall Audit"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophos_firewall_audit/rules/snmpv3.py
+++ b/sophos_firewall_audit/rules/snmpv3.py
@@ -30,7 +30,7 @@ def eval_snmpv3(fw_obj: SophosFirewall,
     
     for i in range(1,3):
         try:
-            result = fw_obj.get_snmpv3_user()
+            result = fw_obj.get_tag_with_filter(xml_tag="SNMPv3User", key="Username", value=expected["Username"])
         except SophosFirewallZeroRecords:
             result = None
             break
@@ -47,7 +47,7 @@ def eval_snmpv3(fw_obj: SophosFirewall,
     if result:
         actual = result["Response"]["SNMPv3User"]
     else:
-        actual = {}
+        actual = {"Username": "User not found"}
 
     result_dict = {
         "snmpv3": {


### PR DESCRIPTION
Look up snmpv3 user by Username and then compare settings. If user is not found, then fail all snmpv3 tests.