### PR TITLE
fix issue with syslog ATP events renaming in v22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophos-firewall-audit"
-version = "1.0.12"
+version = "1.0.13"
 description = "Sophos Firewall Audit"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophos_firewall_audit/rules/syslog.py
+++ b/sophos_firewall_audit/rules/syslog.py
@@ -59,7 +59,12 @@ def eval_syslog(fw_obj: SophosFirewall,
                 settings_dict[settings_category][setting]["Name"] = container_name
                 settings_dict[settings_category][setting]["Expected"] = settings_container['LogSettings'][settings_category][setting]
                 if container_name in actual_settings:
-                    settings_dict[settings_category][setting]["Actual"] = actual_settings[container_name][settings_category][setting]
+                    # Fix for v22 where settings under LogSettings > ATP were changed
+                    # Makes sure the setting actually exists before trying to access it
+                    if setting in actual_settings[container_name][settings_category]: 
+                        settings_dict[settings_category][setting]["Actual"] = actual_settings[container_name][settings_category][setting]
+                    else:
+                        settings_dict[settings_category].pop(setting)
                 else:
                     settings_dict[settings_category][setting]["Actual"] = f"{container_name} not configured!"
         results.append(settings_dict)


### PR DESCRIPTION
ATP Events in v22 were renamed, causing a KeyError when trying to access the key "ATPEvents".  This fix checks for existence of the key specified in the audit settings in the actual response from the API, and if not there removes the key from the expected settings. 