### PR TITLE
Fix loginsecurity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ sophos_firewall_audit/results_html*
 firewalls.yaml
 /rule_export*
 error.log
+.venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophos-firewall-audit"
-version = "1.0.20"
+version = "1.0.21"
 description = "Sophos Firewall Audit"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 readme = "README.md"

--- a/sophos_firewall_audit/rules/loginsecurity.py
+++ b/sophos_firewall_audit/rules/loginsecurity.py
@@ -60,6 +60,9 @@ def eval_loginsecurity(fw_obj: SophosFirewall, fw_name: str, settings: dict):
                 settings_dict[key][category] = {}
                 if isinstance(expected_settings[key][category], dict):
                     for subcategory in expected_settings[key][category]:
+                        # FIX: IncludeNumericCharacter is only available in v22 and above, so skip this check for earlier versions
+                        if subcategory == "IncludeNumericCharacter" and not result["Response"]["@APIVersion"].startswith("22"):
+                            continue
                         settings_dict[key][category][subcategory] = {}
                         settings_dict[key][category][subcategory][
                             "expected"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"


### PR DESCRIPTION
Allow audit of IncludeNumericCharacter password complexity setting in v22 or greater, without causing a KeyError crash. 