### PR TITLE
Remove unused pkg_resources import

### DIFF
--- a/sophos_firewall_audit/audit.py
+++ b/sophos_firewall_audit/audit.py
@@ -11,7 +11,6 @@ import os
 import yaml
 import logging
 import json
-import pkg_resources
 import html
 html.escape = lambda *args, **kwargs: args[0]
 from jinja2 import Environment, PackageLoader, Template, select_autoescape


### PR DESCRIPTION
pkg_resources is imported by audit.py but is not used, causing a ModuleNotFoundError at startup in environments where the module is unavailable. This fix removes the unused import, allowing sophosfirewallaudit to run without requiring setuptools solely for pkg_resources.
